### PR TITLE
Performance tweaks

### DIFF
--- a/dask_glm/tests/test_models.py
+++ b/dask_glm/tests/test_models.py
@@ -1,0 +1,7 @@
+from dask_glm.models import Optimizer
+
+def generate_2pt_line():
+    '''Generates trivial data.'''
+    X = da.from_array(np.array([[0], [1]]), chunks=2)
+    y = da.from_array(np.array([[0], [1]]), chunks=2)
+    return y,X

--- a/dask_glm/tests/test_utils.py
+++ b/dask_glm/tests/test_utils.py
@@ -1,9 +1,22 @@
-from dask_glm.models import Optimizer
+from dask_glm.utils import dot
 
-def generate_2pt_line():
-    '''Generates trivial data.'''
-    X = da.from_array(np.array([[0], [1]]), chunks=2)
-    y = da.from_array(np.array([[0], [1]]), chunks=2)
-    return y,X
+import numpy as np
+import dask.array as da
 
-class QuadraticFunction(Optimizer):
+
+def test_dot():
+    x = np.arange(6).reshape(2, 3)
+    xx = da.from_array(x, chunks=x.shape)
+    y = np.arange(12).reshape(3, 4)
+    yy = da.from_array(y, chunks=y.shape)
+
+    expected = x.dot(y)
+
+    for a in [x, xx]:
+        for b in [y, yy]:
+            result = dot(a, b)
+            if isinstance(a, da.Array) or isinstance(b, da.Array):
+                assert isinstance(result, da.Array)
+
+            result = da.compute(result)[0]
+            assert np.allclose(expected, result)

--- a/dask_glm/utils.py
+++ b/dask_glm/utils.py
@@ -35,12 +35,12 @@ def log1p(A):
 
 @dispatch(da.Array,np.ndarray)
 def dot(A,B):
-    B = da.from_array(B, chunks=A.shape)
+    B = da.from_array(B, chunks=B.shape)
     return da.dot(A,B)
 
 @dispatch(np.ndarray,da.Array)
 def dot(A,B):
-    A = da.from_array(A, chunks=B.shape)
+    A = da.from_array(A, chunks=A.shape)
     return da.dot(A,B)
 
 @dispatch(np.ndarray,np.ndarray)
@@ -60,8 +60,7 @@ def sum(A):
     return da.sum(A)
 
 def make_y(X, beta=np.array([1.5, -3]), chunks=2):
-    n, p   = X.shape        
+    n, p   = X.shape
     z0     = X.dot(beta)
-    z0     = da.compute(z0)[0]  # ensure z0 is a numpy array
-    y      = np.random.rand(n) < sigmoid(z0)
-    return da.from_array(y, chunks=chunks)
+    y      = da.random.random(z0.shape, chunks=z0.chunks) < sigmoid(z0)
+    return y


### PR DESCRIPTION
This does a few things for performance and correctness:

1.  Keep `y` as a dask array rather than a numpy one (this may introduce a performance regression for threaded use)
2.  Use dispatched `dot` rather than `ndarray.dot` in a few cases
3.  Use numpy for the lstsq computation