### PR TITLE
Persist

### DIFF
--- a/dask_glm/logistic.py
+++ b/dask_glm/logistic.py
@@ -85,11 +85,14 @@ def loglike(Xbeta, y):
     eXbeta = np.exp(Xbeta)
     return np.sum(np.log1p(eXbeta)) - np.dot(y, Xbeta)
 
+
+@jit(nogil=True)
 def compute_stepsize(beta, step, Xbeta, Xstep, y, curr_val, stepSize=1.0,
         armijoMult=0.1, backtrackMult=0.1):
     obeta, oXbeta = beta, Xbeta
     steplen = (step**2).sum()
     lf = curr_val
+    func = 0
     for ii in range(100):
         beta = obeta - stepSize * step
         if ii and np.array_equal(beta, obeta):
@@ -104,6 +107,7 @@ def compute_stepsize(beta, step, Xbeta, Xstep, y, curr_val, stepSize=1.0,
         stepSize *= backtrackMult
 
     return stepSize, beta, Xbeta, func
+
 
 def gradient_descent(X, y, max_steps=100, tol=1e-14):
     '''Michael Grant's implementation of Gradient Descent.'''

--- a/dask_glm/logistic.py
+++ b/dask_glm/logistic.py
@@ -77,21 +77,15 @@ def bfgs(X, y, max_iter=50, tol=1e-14):
 
     return beta
 
-@jit
+@jit(nogil=True)
 def loglike(Xbeta, y):
 #        # This prevents overflow
 #        if np.all(Xbeta < 700):
     eXbeta = np.exp(Xbeta)
     return np.sum(np.log1p(eXbeta)) - np.dot(y, Xbeta)
 
-def compute_stepsize(beta, step, Xbeta, Xstep, y, curr_val, **kwargs):
-
-    params = {'stepSize' : 1.0,
-              'armijoMult' : 0.1,
-              'backtrackMult' : 0.1}
-    params.update(kwargs)
-    stepSize, armijo, mult = params['stepSize'], params['armijoMult'], params['backtrackMult']
-
+def compute_stepsize(beta, step, Xbeta, Xstep, y, curr_val, stepSize=1.0,
+        armijoMult=0.1, backtrackMult=0.1):
     obeta, oXbeta = beta, Xbeta
     steplen = (step**2).sum()
     lf = curr_val
@@ -104,9 +98,9 @@ def compute_stepsize(beta, step, Xbeta, Xstep, y, curr_val, **kwargs):
 
         func = loglike(Xbeta, y)
         df = lf - func
-        if df >= armijo * stepSize * steplen:
+        if df >= armijoMult * stepSize * steplen:
             break
-        stepSize *= mult
+        stepSize *= backtrackMult
 
     return stepSize, beta, Xbeta, func
 

--- a/dask_glm/logistic.py
+++ b/dask_glm/logistic.py
@@ -7,12 +7,11 @@ import dask.dataframe as dd
 from numba import jit
 import numpy as np
 
+
 def bfgs(X, y, max_iter=50, tol=1e-14):
     '''Simple implementation of BFGS.'''
 
     n, p = X.shape
-
-    y_local = da.compute(y)[0]
 
     recalcRate = 10
     stepSize = 1.0
@@ -46,10 +45,12 @@ def bfgs(X, y, max_iter=50, tol=1e-14):
         lf = func
         old_Xbeta = Xbeta
         stepSize, beta, Xbeta, func = delayed(compute_stepsize, nout=4)(beta, step,
-                Xbeta, Xstep, y_local, func, backtrackMult=backtrackMult,
+                Xbeta, Xstep, y, func, backtrackMult=backtrackMult,
                 armijoMult=armijoMult, stepSize=stepSize)
 
-        stepSize, Xbeta, gradient, lf, func, step = persist(stepSize, Xbeta, gradient, lf, func, step)
+        beta, Xstep, stepSize, Xbeta, gradient, lf, func, step = persist(
+          beta, Xstep, stepSize, Xbeta, gradient, lf, func, step)
+
         Xbeta = da.from_delayed(Xbeta, shape=old_Xbeta.shape, dtype=old_Xbeta.dtype)
 
         stepSize, lf, func = compute(stepSize, lf, func)


### PR DESCRIPTION
Depends on  https://github.com/dask/dask/pull/1927

This modifies the bfgs algorithm to improve efficiency on a distributed cluster in a couple of ways:

1.  We use persist rather than compute to keep most data up on the cluster.  Variables like Xbeta no longer repeatedly transfer between the client and cluster.
2.  We numba compile compute_stepsize (though I haven't actually measured the performance impact here.

![image](https://cloud.githubusercontent.com/assets/306380/22206338/d5eee21e-e148-11e6-975a-a0e6e39626fd.png)

```python
import dask.array as da
import numpy as np
from dask_glm.logistic import *
from dask_glm.utils import *

N = 5e7
chunks = 1e6
seed = 20009

X = da.random.random((N,2), chunks=(chunks, 2))
y = make_y(X, beta=np.array([-1.5, 3]), chunks=chunks)

if __name__ == '__main__':
    from distributed import Client
    c = Client('localhost:8786')
    c
    X = c.persist(X)
    y = c.persist(y)

    bfgs(X,y,tol=1e-8, max_iter=3)
```

Compute_stepsize is definitely the bottleneck here.  

Also, I'm not sure to which branch I should be submitting work, master or no_api.  It would be nice to merge them at some point 